### PR TITLE
Consume spec issue 8 new tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.6.1</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.tcp.spec.version>0.6</nukleus.tcp.spec.version>
+    <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.6.1</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>
+    <nukleus.tcp.spec.version>0.7</nukleus.tcp.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.1</reaktor.version>
   </properties>

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
@@ -348,9 +348,9 @@ public class ClientIT
     @Test
     @Specification({
         "${route}/output/new/controller",
-        "${streams}/echo.data/client/source"
+        "${streams}/client.and.server.sent.data.multiple.frames/client/source"
     })
-    public void shouldEchoData() throws Exception
+    public void shouldSendAndReceiveData() throws Exception
     {
         try (ServerSocketChannel server = ServerSocketChannel.open())
         {

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
@@ -117,7 +117,7 @@ public class ClientIT
     @Test
     @Specification({
         "${route}/output/new/controller",
-        "${streams}/server.sent.data.overflow/client/source"
+        "${streams}/server.sent.data.flow.control/client/source"
     })
     public void shouldReceiveServerSentDataWithFlowControl() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
@@ -117,6 +117,36 @@ public class ClientIT
     @Test
     @Specification({
         "${route}/output/new/controller",
+        "${streams}/server.sent.data.exceeding.window/client/source"
+    })
+    public void shouldReceiveServerSentDataWithFlowControl() throws Exception
+    {
+        try (ServerSocketChannel server = ServerSocketChannel.open())
+        {
+            server.setOption(SO_REUSEADDR, true);
+            server.bind(new InetSocketAddress("127.0.0.1", 0x1f90));
+
+            k3po.start();
+            k3po.awaitBarrier("ROUTED_OUTPUT");
+
+            try (SocketChannel channel = server.accept())
+            {
+                k3po.notifyBarrier("ROUTED_INPUT");
+
+                channel.write(UTF_8.encode("server data"));
+
+                k3po.finish();
+            }
+        }
+
+        assertEquals(1, counters.streams());
+        assertEquals(1, counters.routes());
+        assertEquals(0, counters.overflows());
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
         "${streams}/server.sent.data.multiple.frames/client/source"
     })
     public void shouldReceiveServerSentDataMultipleFrames() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
@@ -117,7 +117,7 @@ public class ClientIT
     @Test
     @Specification({
         "${route}/output/new/controller",
-        "${streams}/server.sent.data.exceeding.window/client/source"
+        "${streams}/server.sent.data.overflow/client/source"
     })
     public void shouldReceiveServerSentDataWithFlowControl() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
@@ -299,9 +299,9 @@ public class ServerIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/echo.data/server/target"
+        "${streams}/client.and.server.sent.data.multiple.frames/server/target"
     })
-    public void shouldEchoData() throws Exception
+    public void shouldSendAndReceiveData() throws Exception
     {
         k3po.start();
         k3po.awaitBarrier("ROUTED_INPUT");

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
@@ -229,7 +229,7 @@ public class ServerIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/client.sent.data.overflow/server/target"
+        "${streams}/client.sent.data.flow.control/server/target"
     })
     public void shouldReceiveClientSentDataWithFlowControl() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
@@ -229,6 +229,29 @@ public class ServerIT
     @Test
     @Specification({
         "${route}/input/new/controller",
+        "${streams}/client.sent.data.exceeding.window/server/target"
+    })
+    public void shouldReceiveClientSentDataWithFlowControl() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+
+        try (SocketChannel channel = SocketChannel.open())
+        {
+            channel.connect(new InetSocketAddress("127.0.0.1", 0x1f90));
+            channel.write(UTF_8.encode("client data"));
+
+            k3po.finish();
+        }
+
+        assertEquals(1, counters.streams());
+        assertEquals(0, counters.routes());
+        assertEquals(0, counters.overflows());
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/controller",
         "${streams}/client.sent.data.multiple.frames/server/target"
     })
     public void shouldReceiveClientSentDataMultipleFrames() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
@@ -229,7 +229,7 @@ public class ServerIT
     @Test
     @Specification({
         "${route}/input/new/controller",
-        "${streams}/client.sent.data.exceeding.window/server/target"
+        "${streams}/client.sent.data.overflow/server/target"
     })
     public void shouldReceiveClientSentDataWithFlowControl() throws Exception
     {


### PR DESCRIPTION
- Added new test cases client.sent.data.exceeding.window, server.sent.data.exceeding.window.
- Fixed reader StreamFactory.Stream.handleRead to assert readableBytes  > 0 rather than just closing the channel if it is 0 since value 0 should never arise.
- Fixed a couple of sporadic test failures
- Renamed echo.data test case for improved clarity