### PR TITLE
Failure to connect causes repeated IOExceptions surfaced up to the reaktor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.6.1</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>
+    <nukleus.tcp.spec.version>0.8</nukleus.tcp.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.2</reaktor.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jmh.version>1.12</jmh.version>
     <nukleus.plugin.version>0.6.1</nukleus.plugin.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.tcp.spec.version>0.7</nukleus.tcp.spec.version>
+    <nukleus.tcp.spec.version>develop-SNAPSHOT</nukleus.tcp.spec.version>
     <reaktor.test.version>0.2</reaktor.test.version>
     <reaktor.version>0.2</reaktor.version>
   </properties>

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/connector/Connector.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/connector/Connector.java
@@ -120,7 +120,6 @@ public final class Connector extends TransportPoller implements Nukleus
         catch (Exception ex)
         {
             handleConnectFailed(request);
-            LangUtil.rethrowUnchecked(ex);
         }
         finally
         {

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/reader/Reader.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/reader/Reader.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.function.LongFunction;
 import java.util.function.Predicate;
 
 import org.agrona.CloseHelper;
@@ -44,6 +45,7 @@ import org.reaktivity.nukleus.tcp.internal.Context;
 import org.reaktivity.nukleus.tcp.internal.acceptor.Acceptor;
 import org.reaktivity.nukleus.tcp.internal.conductor.Conductor;
 import org.reaktivity.nukleus.tcp.internal.layouts.StreamsLayout;
+import org.reaktivity.nukleus.tcp.internal.router.Correlation;
 import org.reaktivity.nukleus.tcp.internal.router.RouteKind;
 
 /**
@@ -64,17 +66,19 @@ public final class Reader extends Nukleus.Composite
     private final AtomicBuffer writeBuffer;
     private final Long2ObjectHashMap<List<Route>> routesByRef;
 
+
     public Reader(
         Context context,
         Conductor conductor,
         Acceptor acceptor,
-        String sourceName)
+        String sourceName,
+        LongFunction<Correlation> resolveCorrelation)
     {
         this.context = context;
         this.conductor = conductor;
         this.acceptor = acceptor;
         this.sourceName = sourceName;
-        this.source = include(new Source(sourceName, context.maxMessageLength()));
+        this.source = include(new Source(sourceName, context.maxMessageLength(), resolveCorrelation));
         this.writeBuffer = new UnsafeBuffer(new byte[context.maxMessageLength()]);
         this.targetsByName = new TreeMap<>();
         this.routesByRef = new Long2ObjectHashMap<>();

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/router/Router.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/router/Router.java
@@ -442,7 +442,7 @@ public final class Router extends Nukleus.Composite
     private Reader newReader(
         String sourceName)
     {
-        return include(new Reader(context, conductor, acceptor, sourceName));
+        return include(new Reader(context, conductor, acceptor, sourceName, correlations::remove));
     }
 
     private Writer newWriter(

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ClientIT.java
@@ -87,6 +87,18 @@ public class ClientIT
     @Test
     @Specification({
         "${route}/output/new/controller",
+        "${streams}/connection.failed/client/source"
+    })
+    public void connnectionFailed() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/controller",
         "${streams}/server.sent.data/client/source"
     })
     public void shouldReceiveServerSentData() throws Exception

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
@@ -22,7 +22,6 @@ import static org.junit.rules.RuleChain.outerRule;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 
@@ -95,10 +94,6 @@ public class ServerIT
         try (SocketChannel channel = SocketChannel.open())
         {
             channel.connect(new InetSocketAddress("127.0.0.1", 0x1f90));
-            channel.setOption(StandardSocketOptions.TCP_NODELAY, true);
-
-            // Write should result in reset (RST) from other end, so IOException from read
-            channel.write(UTF_8.encode("client data which should cause a reset at the other end"));
 
             ByteBuffer buf = ByteBuffer.allocate(256);
             try

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
@@ -22,6 +22,7 @@ import static org.junit.rules.RuleChain.outerRule;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 
@@ -94,9 +95,10 @@ public class ServerIT
         try (SocketChannel channel = SocketChannel.open())
         {
             channel.connect(new InetSocketAddress("127.0.0.1", 0x1f90));
+            channel.setOption(StandardSocketOptions.TCP_NODELAY, true);
 
             // Write should result in reset (RST) from other end, so IOException from read
-            channel.write(UTF_8.encode("client data"));
+            channel.write(UTF_8.encode("client data which should cause a reset at the other end"));
 
             ByteBuffer buf = ByteBuffer.allocate(256);
             try

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/ServerIT.java
@@ -81,6 +81,39 @@ public class ServerIT
         assertEquals(0, counters.overflows());
     }
 
+    @Test(expected = IOException.class)
+    @Specification({
+        "${route}/input/new/controller",
+        "${streams}/connection.failed/server/target"
+    })
+    public void connectionFailed() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_INPUT");
+
+        try (SocketChannel channel = SocketChannel.open())
+        {
+            channel.connect(new InetSocketAddress("127.0.0.1", 0x1f90));
+
+            // Write should result in reset (RST) from other end, so IOException from read
+            channel.write(UTF_8.encode("client data"));
+
+            ByteBuffer buf = ByteBuffer.allocate(256);
+            try
+            {
+                channel.read(buf);
+            }
+            finally
+            {
+                k3po.finish();
+            }
+        }
+
+        assertEquals(0, counters.streams());
+        assertEquals(0, counters.routes());
+        assertEquals(0, counters.overflows());
+    }
+
     @Test
     @Specification({
         "${route}/input/new/controller",


### PR DESCRIPTION
Added test cases connection.failed. Fixed looping error from failed connect in Connector: do not rethrow the exception.