### PR TITLE
Fix unbind issues on Windows

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/poller/Poller.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/poller/Poller.java
@@ -70,6 +70,9 @@ public final class Poller extends TransportPoller implements Nukleus
         {
             quietClose(key.channel());
         }
+
+        // Allow proper cleanup on platforms like Windows
+        selectNowWithoutProcessing();
     }
 
     public PollerKey doRegister(


### PR DESCRIPTION
Fix for issue #22:
Added a call to selectNowWithoutProcessing (TransportPoller method) from Poller.close() to resolve issues with sockets not being unbound on Windows. 