### PR TITLE
Fix manifest for jmh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
                   implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
                   <manifestEntries>
-                    <Class-Path>${project.build.directory}/${project.artifactId}-shaded.jar</Class-Path>
+                    <Class-Path>${project.artifactId}-shaded.jar</Class-Path>
                   </manifestEntries>
                 </transformer>
               </transformers>


### PR DESCRIPTION
Removed ${project.build.directory}/ from manifest classpath entry for shaded test jar so it works on all platforms (notably Windows).