### PR TITLE
Closed the FileChannel in StreamsLayer.build() to allow streams files to be deleted

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/layouts/StreamsLayout.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/layouts/StreamsLayout.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.nio.MappedByteBuffer;
 import java.nio.file.Path;
 
+import org.agrona.CloseHelper;
 import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.OneToOneRingBuffer;
@@ -103,7 +104,7 @@ public final class StreamsLayout extends Layout
 
             if (!readonly)
             {
-                createEmptyFile(streams, streamsSize + throttleSize);
+                CloseHelper.close(createEmptyFile(streams, streamsSize + throttleSize));
             }
 
             final MappedByteBuffer mappedStreams = mapExistingFile(streams, "streams", 0, streamsSize);

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/router/RouteKind.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/router/RouteKind.java
@@ -24,7 +24,7 @@ public enum RouteKind
     INPUT_NEW
     {
         @Override
-        protected final long nextRef(
+        protected long nextRef(
             LongSupplier getAndIncrement)
         {
             // positive, even, non-zero
@@ -35,7 +35,7 @@ public enum RouteKind
     OUTPUT_ESTABLISHED
     {
         @Override
-        protected final long nextRef(
+        protected long nextRef(
             LongSupplier getAndIncrement)
         {
             // negative, even, non-zero
@@ -46,7 +46,7 @@ public enum RouteKind
     OUTPUT_NEW
     {
         @Override
-        protected final long nextRef(
+        protected long nextRef(
             LongSupplier getAndIncrement)
         {
             // positive, odd
@@ -57,7 +57,7 @@ public enum RouteKind
     INPUT_ESTABLISHED
     {
         @Override
-        protected final long nextRef(
+        protected long nextRef(
             LongSupplier getAndIncrement)
         {
             // negative, odd

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/layouts/StreamsLayoutTest.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/layouts/StreamsLayoutTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.tcp.internal.layouts;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+public final class StreamsLayoutTest
+{
+
+    @Test
+    public void shouldUnlockStreamsFile() throws Exception
+    {
+        String fileName = "target/nukleus-itests/client/streams/server";
+        Path streams = Paths.get(fileName);
+        StreamsLayout streamsLayout = new StreamsLayout.Builder()
+                .path(streams)
+                .streamsCapacity(8192)
+                .throttleCapacity(8192)
+                .readonly(false)
+                .build();
+        streamsLayout.close();
+        assertTrue(Files.exists(streams));
+        Files.delete(streams);
+    }
+
+}


### PR DESCRIPTION
This is the same fix as https://github.com/reaktivity/k3po-nukleus-ext.java/pull/3. Also removed redundant final modifiers from RouteKind.