### PR TITLE
readyOps has operations that are not interestOps

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/poller/Poller.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/poller/Poller.java
@@ -17,7 +17,6 @@ package org.reaktivity.nukleus.tcp.internal.poller;
 
 import static org.agrona.CloseHelper.quietClose;
 
-import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
@@ -49,8 +48,9 @@ public final class Poller extends TransportPoller implements Nukleus
                 workDone = selectedKeySet.forEach(selectHandler);
             }
         }
-        catch (IOException ex)
+        catch (Throwable ex)
         {
+            selectedKeySet.reset();
             LangUtil.rethrowUnchecked(ex);
         }
 

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/poller/PollerKey.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/poller/PollerKey.java
@@ -106,6 +106,7 @@ public final class PollerKey
     int handleSelect(
         SelectionKey key)
     {
+        // guarantee ready set matches interest ops, see SelectionKey
         final int readyOps = key.readyOps() & this.interestOps;
 
         int workDone = 0;

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/poller/PollerKey.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/poller/PollerKey.java
@@ -106,7 +106,7 @@ public final class PollerKey
     int handleSelect(
         SelectionKey key)
     {
-        final int readyOps = key.readyOps();
+        final int readyOps = key.readyOps() & this.interestOps;
 
         int workDone = 0;
 


### PR DESCRIPTION
readyOps has operations that are not interestOps. Not sure if this is JDK bug.
Now, we call the handlers that have registered in interestOps.

This fixes https://github.com/reaktivity/nukleus-tcp.java/issues/34