### PR TITLE
Uptake latest nukleus-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <k3po.version>3.0.0-alpha-79</k3po.version>
     <k3po.nukleus.ext.version>0.8.2</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.plugin.version>0.11</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
     <nukleus.tcp.spec.version>0.17</nukleus.tcp.spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <k3po.version>3.0.0-alpha-79</k3po.version>
     <k3po.nukleus.ext.version>0.8.2</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.10</nukleus.plugin.version>
+    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
     <nukleus.tcp.spec.version>0.17</nukleus.tcp.spec.version>

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/ClientStreamFactory.java
@@ -310,7 +310,7 @@ public class ClientStreamFactory implements StreamFactory
                 channel.finishConnect();
                 handleConnected(this);
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 handleConnectFailed(this);
             }

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/MessageWriter.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/MessageWriter.java
@@ -82,9 +82,9 @@ final class MessageWriter
         InetSocketAddress remoteAddress)
     {
         BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
+                .streamId(streamId)
                 .source(SOURCE_NAME_BUFFER, 0, SOURCE_NAME_BUFFER.capacity())
                 .sourceRef(referenceId)
-                .streamId(streamId)
                 .correlationId(correlationId)
                 .extension(b -> b.set(visitBeginEx(localAddress, remoteAddress)))
                 .build();


### PR DESCRIPTION
Set streamId first on begin to respect call order for FW Builder mutators.
Catch IOException not Exception in ClientStreamFactory to avoid hiding exceptions.

Requires PR https://github.com/reaktivity/nukleus-maven-plugin/pull/30