### PR TITLE
Partial write when there is already data in the slot

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/WriteStream.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/WriteStream.java
@@ -181,7 +181,8 @@ public final class WriteStream
 
         if (reduceWindow(writableBytes))
         {
-            ByteBuffer writeBuffer = getWriteBuffer(buffer, payload.offset(), writableBytes);
+            final ByteBuffer writeBuffer = getWriteBuffer(buffer, payload.offset(), writableBytes);
+            final int remainingBytes = writeBuffer.remaining();
 
             int bytesWritten = 0;
 
@@ -193,7 +194,7 @@ public final class WriteStream
             int originalSlot = slot;
             if (handleUnwrittenData(writeBuffer, bytesWritten))
             {
-                if (bytesWritten < writableBytes)
+                if (bytesWritten < remainingBytes)
                 {
                     key.register(OP_WRITE);
                 }

--- a/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/rfc793/ServerPartialWriteIT.java
+++ b/src/test/java/org/reaktivity/nukleus/tcp/internal/streams/rfc793/ServerPartialWriteIT.java
@@ -137,6 +137,25 @@ public class ServerPartialWriteIT
 
     @Test
     @Specification({
+            "${route}/server/controller",
+            "${server}/server.sent.data.multiple.frames/server",
+            "${client}/server.sent.data.multiple.frames/client"
+    })
+    public void shouldPartiallyWriteWhenMoreDataArrivesWhileAwaitingSocketWritable() throws Exception
+    {
+        // processData will be called for each of the two data frames. Make the first and second
+        // each do a partial write, then write nothing until handleWrite is called after the
+        // second processData call, when we write everything.
+        AtomicBoolean finishWrite = new AtomicBoolean(false);
+
+        ProcessDataHelper.fragmentWrites(concat(of(5), generate(() -> finishWrite.getAndSet(true) ? 0 : 15)));
+        HandleWriteHelper.fragmentWrites(generate(() -> finishWrite.get() ? ALL : 0));
+
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${route}/server/controller",
         "${server}/server.sent.data.then.end/server"
     })


### PR DESCRIPTION
When there is pending data to be written in slot and DATA arrives, it was appended in
the slot. But the writable bytes needs to be updated with the total data in the slot (
otherwise, OP_WRITE is cleared since it was checking only with DATA frame's length instead of checking with the total data length).