### PR TITLE
Disabled Nagle's algorithm on all socket connections to reduce latency.

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/Acceptor.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/Acceptor.java
@@ -16,6 +16,7 @@
 package org.reaktivity.nukleus.tcp.internal.stream;
 
 import static java.net.StandardSocketOptions.SO_REUSEADDR;
+import static java.net.StandardSocketOptions.TCP_NODELAY;
 import static java.nio.channels.SelectionKey.OP_ACCEPT;
 import static org.reaktivity.nukleus.tcp.internal.util.IpUtil.compareAddresses;
 import static org.reaktivity.nukleus.tcp.internal.util.IpUtil.inetAddress;
@@ -184,6 +185,7 @@ public final class Acceptor
 
             final SocketChannel channel = serverChannel.accept();
             channel.configureBlocking(false);
+            channel.setOption(TCP_NODELAY, true);
 
             final InetSocketAddress address = localAddress(channel);
             final String sourceName = sourcesByLocalAddress.get(address);

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/ClientStreamFactory.java
@@ -15,6 +15,7 @@
  */
 package org.reaktivity.nukleus.tcp.internal.stream;
 
+import static java.net.StandardSocketOptions.TCP_NODELAY;
 import static java.nio.ByteOrder.nativeOrder;
 import static java.nio.channels.SelectionKey.OP_CONNECT;
 import static java.nio.channels.SelectionKey.OP_READ;
@@ -236,6 +237,7 @@ public class ClientStreamFactory implements StreamFactory
 
         try
         {
+            channel.setOption(TCP_NODELAY, true);
             final InetSocketAddress localAddress = (InetSocketAddress) channel.getLocalAddress();
             final InetSocketAddress remoteAddress = (InetSocketAddress) channel.getRemoteAddress();
             final MessageConsumer target = router.supplyTarget(targetName);

--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/ClientStreamFactory.java
@@ -172,6 +172,7 @@ public class ClientStreamFactory implements StreamFactory
         {
             final SocketChannel channel = SocketChannel.open();
             channel.configureBlocking(false);
+            channel.setOption(TCP_NODELAY, true);
             return channel;
         }
         catch (IOException ex)
@@ -237,7 +238,6 @@ public class ClientStreamFactory implements StreamFactory
 
         try
         {
-            channel.setOption(TCP_NODELAY, true);
             final InetSocketAddress localAddress = (InetSocketAddress) channel.getLocalAddress();
             final InetSocketAddress remoteAddress = (InetSocketAddress) channel.getRemoteAddress();
             final MessageConsumer target = router.supplyTarget(targetName);


### PR DESCRIPTION
This is needed for example to reduce perceived latency when tcp nukleus is used with http nukleus to create an http server or proxy.