### PR TITLE
Handle UnresolvedAddressException while connecting

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/ClientStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/tcp/internal/stream/ClientStreamFactory.java
@@ -28,6 +28,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.UnresolvedAddressException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -359,7 +360,7 @@ public class ClientStreamFactory implements StreamFactory
                 poller.doRegister(channel, OP_CONNECT, request);
             }
         }
-        catch (IOException ex)
+        catch (UnresolvedAddressException | IOException ex)
         {
             handleConnectFailed(request);
             rethrowUnchecked(ex);


### PR DESCRIPTION
Currently, RA crashes if it can't resolve the one of the service urls. I would not expect it to crash since there may be other urls that will loos cache history.